### PR TITLE
Fix server port log

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const https = require('https');
 const config = require('./config.json');
 
 const apiKeys = config.apiKeys;
+const PORT = 3456;
 
 let currentApiKeyIndex = 0;
 let attemptCount = 0;
@@ -123,6 +124,6 @@ http.createServer((req, res) => {
       res.end(JSON.stringify({ error: 'Invalid JSON payload' }));
     }
   });
-}).listen(3456, 'localhost', () => {
-  console.log('Server running at http://localhost:3000/');
+}).listen(PORT, 'localhost', () => {
+  console.log(`Server running at http://localhost:${PORT}/`);
 });


### PR DESCRIPTION
## Summary
- keep port in a `PORT` constant
- use the constant when listening and logging server URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4895eb248322a335e2b3f5d222ba