### PR TITLE
Fix config json example placeholders

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,21 +1,20 @@
-  {
-    "apiKeys": [
-      {
-        "key": "api-key-1",
-        "url": "api-base-url-1",
-        "models": [model that this api key use]
-      },
-      {
-        "key": "api-key-2",
-        "url": "api-base-url-2",
-        "models": [ ]
-      },
-      {
-        "key": "another_api_key_here",
-        "url": "https://api.another.com",
-        "models": [ ]
-      }
-    ]
-  }
-  
-//"gpt-3.5-turbo", "gpt-4", "others"
+{
+  "_comment": "Example models: gpt-3.5-turbo, gpt-4, others",
+  "apiKeys": [
+    {
+      "key": "api-key-1",
+      "url": "api-base-url-1",
+      "models": ["model that this API key uses"]
+    },
+    {
+      "key": "api-key-2",
+      "url": "api-base-url-2",
+      "models": []
+    },
+    {
+      "key": "another_api_key_here",
+      "url": "https://api.another.com",
+      "models": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- update `config.json.example` to use quoted model names
- add an `_comment` field explaining possible values

## Testing
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("config.json.example")); console.log("ok")'`

------
https://chatgpt.com/codex/tasks/task_e_683f48a5fe308322a6306e3cf55d20ae