### PR TITLE
Bind server to all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ Here's an example of how it could be configured:
 
 
 ## Usage
-Start the server by running the command `node server.js`
+Start the server by running the command `node server.js`.
 
-The server will automatically handle the routing and key rotation for you
+By default the proxy listens on port `3456` on all network interfaces, so it can
+be reached from other machines using `http://<server-ip>:3456`. The server will
+automatically handle the routing and key rotation for you.
 
 ## Planned
 - [x] choose the best latency proxy

--- a/server.js
+++ b/server.js
@@ -170,6 +170,6 @@ http.createServer((req, res) => {
       res.end(JSON.stringify({ error: 'Invalid JSON payload' }));
     }
   });
-}).listen(PORT, 'localhost', () => {
-  console.log(`Server running at http://localhost:${PORT}/`);
+}).listen(PORT, '0.0.0.0', () => {
+  console.log(`Server running at http://0.0.0.0:${PORT}/`);
 });


### PR DESCRIPTION
## Summary
- fix server to listen on `0.0.0.0` instead of localhost
- clarify proxy port and host in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f4ab342a08322a081159d3ca1c5d9